### PR TITLE
More separate compose

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -21,15 +21,15 @@ plugins {
     kotlin("android")
 }
 
-val composeVersion = "1.0.0-beta02"
+val composeVersion = "1.0.0-beta06"
 
 android {
-    compileSdkVersion(30)
+    compileSdk = 30
 
     defaultConfig {
         applicationId = "dev.marcelpinto.permissionktx.sample"
-        minSdkVersion(21)
-        targetSdkVersion(30)
+        minSdk = 21
+        targetSdk = 30
         versionCode = 1
         versionName = "1.0"
 
@@ -39,11 +39,9 @@ android {
     buildTypes {
         named("release") {
             isMinifyEnabled = false
-            setProguardFiles(
-                listOf(
-                    getDefaultProguardFile("proguard-android-optimize.txt"),
-                    "proguard-rules.pro"
-                )
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro"
             )
         }
     }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -77,21 +77,21 @@ dependencies {
     implementation(project(":lib"))
 
     implementation("androidx.core:core-ktx:1.3.2")
-    implementation("androidx.appcompat:appcompat:1.3.0-beta01")
+    implementation("androidx.appcompat:appcompat:1.3.0-rc01")
     implementation("androidx.constraintlayout:constraintlayout:2.0.4")
 
     implementation("com.google.android.material:material:1.3.0")
     implementation("androidx.compose.ui:ui:$composeVersion")
     implementation("androidx.compose.material:material:$composeVersion")
-    implementation("androidx.activity:activity-compose:1.3.0-alpha04")
-    implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.3.0")
-    implementation("androidx.lifecycle:lifecycle-livedata-ktx:2.3.0")
-    implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.3.0")
+    implementation("androidx.activity:activity-compose:1.3.0-alpha07")
+    implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.3.1")
+    implementation("androidx.lifecycle:lifecycle-livedata-ktx:2.3.1")
+    implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.3.1")
 
     testImplementation("junit:junit:4.13.2")
     testImplementation("androidx.arch.core:core-testing:2.1.0")
     testImplementation("com.google.truth:truth:1.0.1")
-    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.4.2")
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.4.3")
 
     androidTestImplementation("androidx.test:core-ktx:1.3.0")
     androidTestImplementation("androidx.test.ext:junit-ktx:1.1.2")

--- a/app/src/main/java/dev/marcelpinto/permissionktx/compose/ComposeActivity.kt
+++ b/app/src/main/java/dev/marcelpinto/permissionktx/compose/ComposeActivity.kt
@@ -16,19 +16,12 @@
 
 package dev.marcelpinto.permissionktx.compose
 
-import android.Manifest
-import android.content.Intent
-import android.net.Uri
 import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.appcompat.app.AppCompatActivity
+import androidx.compose.foundation.layout.Column
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Surface
-import androidx.compose.runtime.MutableState
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.saveable.rememberSaveable
-import dev.marcelpinto.permissionktx.PermissionLauncher
-import dev.marcelpinto.permissionktx.registerForPermissionResult
 
 /**
  * The compose example, shows a simple dialer app that follows the permission flow by:
@@ -38,42 +31,16 @@ import dev.marcelpinto.permissionktx.registerForPermissionResult
  *   - Launching the call once permission is granted
  */
 class ComposeActivity : AppCompatActivity() {
-
-    // Register the permission request in the parent activity. This ensure that the state is handle
-    // properly even after activity recreation.
-    //
-    // The callback is called after permission request result.
-    private val permissionLauncher: PermissionLauncher =
-        registerForPermissionResult(Manifest.permission.CALL_PHONE) { granted ->
-            if (granted) {
-                startCall(phoneNumber.value)
-            }
-        }
-
-    // Keeping the variable here allows us to use it in the permission request callback and ensures
-    // it's restored on activity restart because we use savedInstanceState below.
-    private lateinit var phoneNumber: MutableState<String>
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {
             MaterialTheme {
                 Surface(color = MaterialTheme.colors.background) {
-                    phoneNumber = rememberSaveable { mutableStateOf("") }
-                    ComposePermissionScreen(phoneNumber, permissionLauncher) { phone ->
-                        // in case the permission was already granted we can call startCall directly
-                        startCall(phone)
+                    Column {
+                        ComposePermissionScreen()
                     }
                 }
             }
         }
-    }
-
-    private fun startCall(phone: String) {
-        val phoneCallUri = Uri.parse("tel:$phone")
-        val phoneCallIntent = Intent(Intent.ACTION_CALL).also {
-            it.data = phoneCallUri
-        }
-        startActivity(phoneCallIntent)
     }
 }

--- a/app/src/main/java/dev/marcelpinto/permissionktx/compose/ComposePermissionLauncher.kt
+++ b/app/src/main/java/dev/marcelpinto/permissionktx/compose/ComposePermissionLauncher.kt
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2020 Marcel Pinto Biescas
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.marcelpinto.permissionktx.compose
+
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.contract.ActivityResultContract
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.runtime.Composable
+import androidx.core.app.ActivityOptionsCompat
+import dev.marcelpinto.permissionktx.Permission
+import dev.marcelpinto.permissionktx.PermissionProvider
+import dev.marcelpinto.permissionktx.PermissionRational
+import dev.marcelpinto.permissionktx.PermissionStatus
+
+internal class ComposePermissionLauncher(
+    private val type: Permission,
+    private val resultLauncher: ActivityResultLauncher<String>
+) : ActivityResultLauncher<String>() {
+    override fun launch(input: String?, options: ActivityOptionsCompat?) {
+        resultLauncher.launch(type.name, options)
+    }
+
+    override fun unregister() {
+        resultLauncher.unregister()
+    }
+
+    override fun getContract(): ActivityResultContract<String, *> = resultLauncher.contract
+}
+
+internal fun createResultCallback(onResult: (Boolean) -> Unit): (Boolean) -> Unit = {
+    PermissionProvider.instance.observer.refreshStatus()
+    onResult(it)
+}
+
+@Composable
+internal fun composePermissionRequest(
+    permission: Permission,
+    options: ActivityOptionsCompat? = null,
+    onRequirePermission: () -> Boolean = { true },
+    onRequireRational: () -> Unit,
+    onAlreadyGranted: () -> Unit = {},
+    onResult: (Boolean) -> Unit = {},
+): (Boolean) -> Unit {
+
+    val activityResultLauncher = composeRegisterForActivityResult(
+        contract = ActivityResultContracts.RequestPermission(),
+        onResult = createResultCallback(onResult)
+    )
+
+    val requestPerm = {
+        forced: Boolean ->
+        if (forced) {
+            activityResultLauncher.launch(permission.name, options)
+        } else {
+            when (val state = permission.status) {
+                is PermissionStatus.Granted -> onAlreadyGranted()
+                is PermissionStatus.Revoked -> if (state.rationale != PermissionRational.OPTIONAL) {
+                    onRequireRational()
+                } else if (onRequirePermission()) {
+                    activityResultLauncher.launch(permission.name, options)
+                }
+            }
+        }
+    }
+
+    ComposePermissionLauncher(permission, activityResultLauncher)
+
+    return requestPerm
+}

--- a/app/src/main/java/dev/marcelpinto/permissionktx/compose/ComposeRegisterForActivityResult.kt
+++ b/app/src/main/java/dev/marcelpinto/permissionktx/compose/ComposeRegisterForActivityResult.kt
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2020 Marcel Pinto Biescas
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.marcelpinto.permissionktx.compose
+
+import android.annotation.SuppressLint
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.ActivityResultRegistryOwner
+import androidx.activity.result.contract.ActivityResultContract
+import androidx.compose.runtime.*
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.ui.platform.LocalContext
+import androidx.core.app.ActivityOptionsCompat
+import java.util.*
+
+@SuppressLint("UnrememberedMutableState")
+@Composable
+internal fun <I, O> composeRegisterForActivityResult(
+    contract: ActivityResultContract<I, O>,
+    onResult: (O) -> Unit
+): ActivityResultLauncher<I> {
+    // First, find the ActivityResultRegistry by casting the Context
+    // (which is actually a ComponentActivity) to ActivityResultRegistryOwner
+    //val owner = LocalContext.current as ActivityResultRegistryOwner
+    val owner = LocalContext.current as ActivityResultRegistryOwner
+    val activityResultRegistry = owner.activityResultRegistry
+
+    // Keep track of the current onResult listener
+    val currentOnResult = rememberUpdatedState(onResult)
+
+    // It doesn't really matter what the key is, just that it is unique
+    // and consistent across configuration changes
+    val key = rememberSaveable { UUID.randomUUID().toString() }
+
+    // Since we don't have a reference to the real ActivityResultLauncher
+    // until we register(), we build a layer of indirection so we can
+    // immediately return an ActivityResultLauncher
+    // (this is the same approach that Fragment.registerForActivityResult uses)
+    val realLauncher = mutableStateOf<ActivityResultLauncher<I>?>(null)
+    val returnedLauncher = remember {
+        object : ActivityResultLauncher<I>() {
+            override fun launch(input: I, options: ActivityOptionsCompat?) {
+                realLauncher.value?.launch(input, options)
+            }
+
+            override fun unregister() {
+                realLauncher.value?.unregister()
+            }
+
+            override fun getContract() = contract
+        }
+    }
+
+    // DisposableEffect ensures that we only register once
+    // and that we unregister when the composable is disposed
+    DisposableEffect(activityResultRegistry, key, contract) {
+        realLauncher.value = activityResultRegistry.register(key, contract) {
+            currentOnResult.value(it)
+        }
+        onDispose {
+            realLauncher.value?.unregister()
+        }
+    }
+    return returnedLauncher
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,8 +21,8 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:7.0.0-alpha09")
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.31")
+        classpath("com.android.tools.build:gradle:7.0.0-alpha15")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.32")
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Mon Nov 30 17:02:27 SGT 2020
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https://services.gradle.org/distributions/gradle-6.8.2-bin.zip
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-bin.zip
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -18,7 +18,6 @@ import com.android.build.gradle.internal.cxx.configure.gradleLocalProperties
 import org.jetbrains.dokka.gradle.DokkaTask
 import org.jetbrains.kotlin.config.KotlinCompilerVersion
 import java.net.URL
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     id("com.android.library")
@@ -29,13 +28,11 @@ plugins {
 }
 
 android {
-    compileSdkVersion(30)
+    compileSdk = 30
 
     defaultConfig {
-        minSdkVersion(21)
-        targetSdkVersion(30)
-        versionCode = 7
-        versionName = "0.7"
+        minSdk = 21
+        targetSdk = 30
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")
@@ -44,11 +41,9 @@ android {
     buildTypes {
         named("release") {
             isMinifyEnabled = false
-            setProguardFiles(
-                listOf(
-                    getDefaultProguardFile("proguard-android-optimize.txt"),
-                    "proguard-rules.pro"
-                )
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro"
             )
         }
     }
@@ -87,7 +82,7 @@ dependencies {
 
 val libraryName = "permissions-ktx"
 val libraryGroup = "dev.marcelpinto.permissions"
-val libraryVersion = android.defaultConfig.versionName.toString()
+val libraryVersion = "0.7"
 
 tasks.withType<DokkaTask>().configureEach {
     dokkaSourceSets {
@@ -119,7 +114,7 @@ val androidHtmlJar by tasks.register<Jar>("androidHtmlJar") {
 
 val androidSourcesJar by tasks.register<Jar>("androidSourcesJar") {
     archiveClassifier.set("sources")
-    from(android.sourceSets.getByName("main").java.srcDirs)
+    from(android.sourceSets.getByName("main").java.srcDirs())
 }
 
 publishing {

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -65,17 +65,17 @@ dependencies {
     implementation(kotlin("stdlib", KotlinCompilerVersion.VERSION))
 
     implementation("androidx.appcompat:appcompat:1.2.0")
-    implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.3.0")
+    implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.3.1")
     implementation("androidx.lifecycle:lifecycle-extensions:2.2.0")
 
     api("androidx.startup:startup-runtime:1.0.0")
-    api("androidx.activity:activity-ktx:1.3.0-alpha04")
-    api("androidx.fragment:fragment-ktx:1.3.0")
+    api("androidx.activity:activity-ktx:1.3.0-alpha07")
+    api("androidx.fragment:fragment-ktx:1.3.3")
 
     testImplementation("junit:junit:4.13.2")
     testImplementation("com.google.truth:truth:1.0.1")
     testImplementation("com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0")
-    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.4.2")
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.4.3")
     testImplementation("org.jetbrains.kotlin:kotlin-test:${KotlinCompilerVersion.VERSION}")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit:${KotlinCompilerVersion.VERSION}")
 }


### PR DESCRIPTION
Moving permission request code into a composable from the activity. Feel free to consider this a POC of moving the permission code out of the activity while still supporting the pesky cornercases around activity recreation that the library aims to support. In my testing this seemed to work. 

Using the response from here: https://stackoverflow.com/a/64722700 I moved the registration of the activity result listener into the composable. This allowed the permission request code to be isolated to the composable - which was my goal.

I realize this code is not perfect - it is however good enough for my current purposes. :)

If you like the idea of separating the code into the composable I'd be open to spend some time with this to improve it some more (for one supporting multiple permissions and making use of the libraries PermissionLauncher somehow)

Sorry for extending my previous PR with this. For obvious reasons I needed AGP and compose to be bumped.

I have tested this on a Nokia 7.2 running Android 10 where it curiously doesn't work. As it turned out - your previous solution doesn't work on that device either. Testing on API 30 emulator and my pixel 4 works just fine. Not sure what is lacking on the Nokia. Testing in this case is enabling "don't keep activities" and app switching.