### PR TITLE
add isInitialized() to PermissionProvider

### DIFF
--- a/lib/src/main/java/dev/marcelpinto/permissionktx/PermissionProvider.kt
+++ b/lib/src/main/java/dev/marcelpinto/permissionktx/PermissionProvider.kt
@@ -49,6 +49,17 @@ class PermissionProvider @OptIn(ExperimentalCoroutinesApi::class) constructor(
             private set
 
         /**
+         * When PermissionProvider self-initialization is disabled, PermissionProvider.init(context)
+         * must be called to manually initialize the PermissionProvider instance. Depending on
+         * implementation if init() is called more than once (multiple times in app OR in app + test),
+         * an IllegalStateException is thrown.
+         *
+         * Provide an easy way to check if PermissionProvider instance is already
+         * initialized, before calling PermissionProvider.init(context).
+         */
+        fun isInitialized() = ::instance.isInitialized
+
+        /**
          * Initialize the PermissionProvider instance and wire the components to check and observe
          * PermissionProvider status changes.
          *

--- a/lib/src/test/java/dev/marcelpinto/permissionktx/PermissionProviderTest.kt
+++ b/lib/src/test/java/dev/marcelpinto/permissionktx/PermissionProviderTest.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2020 Marcel Pinto Biescas
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.marcelpinto.permissionktx
+
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.flow.emptyFlow
+import org.junit.Test
+
+class PermissionProviderTest {
+
+
+    private val fakeChecker = object : PermissionChecker {
+        override fun getStatus(type: Permission) = PermissionStatus.Granted(Permission("any"))
+    }
+
+    private val dummyObserver = object : PermissionObserver {
+        override fun getStatusFlow(type: Permission) = emptyFlow<PermissionStatus>()
+        override fun refreshStatus() {}
+    }
+
+    @Test
+    fun `test isInitialized when PermissionProvider is initialized`() {
+        assertThat(PermissionProvider.isInitialized()).isFalse()
+        PermissionProvider.init(fakeChecker, dummyObserver)
+        assertThat(PermissionProvider.isInitialized()).isTrue()
+    }
+}

--- a/lib/src/test/java/dev/marcelpinto/permissionktx/PermissionProviderTest.kt
+++ b/lib/src/test/java/dev/marcelpinto/permissionktx/PermissionProviderTest.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright 2020 Marcel Pinto Biescas
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *          http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package dev.marcelpinto.permissionktx
 
 import com.google.common.truth.Truth.assertThat


### PR DESCRIPTION
When PermissionProvider self-initialization is disabled, PermissionProvider.init(context) must be called to manually initialize the PermissionProvider instance. Depending on where in the app's flow this init() is called, it is possible it may be triggered more than once, whether its multiple times in the app OR in app + test. Calling init() if the instance is already initialized throws IllegalStateException.

One workaround (not the prettiest) to ensure `PermissionProvider.init(context)` is called only once while handling the exception :
```
try {
    PermissionProvider.init(context)
} catch (e: IllegalStateException) {
    Timber.e("PermissionProvider instance is already initialized")
}
```
This PR provides a cleaner approach of making sure to only call init() if the PermissionProvider instance isn't already initialized.
```
if (!PermissionProvider.isInitialized()) {
    PermissionProvider.init(context)
}
```