### PR TITLE
Bump startup-runtime from 1.0.0 to 1.1.0

### DIFF
--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -66,7 +66,7 @@ dependencies {
 
     implementation("androidx.lifecycle:lifecycle-extensions:2.2.0")
 
-    api("androidx.startup:startup-runtime:1.0.0")
+    api("androidx.startup:startup-runtime:1.1.0")
     api("androidx.activity:activity-ktx:1.3.0-beta01")
     api("androidx.fragment:fragment-ktx:1.3.4")
 


### PR DESCRIPTION
Bumps startup-runtime from 1.0.0 to 1.1.0.

---
updated-dependencies:
- dependency-name: androidx.startup:startup-runtime
  dependency-type: direct:production
  update-type: version-update:semver-minor
...

Signed-off-by: dependabot[bot] <support@github.com>