### PR TITLE
Update license URL

### DIFF
--- a/gradle/publish-module.gradle
+++ b/gradle/publish-module.gradle
@@ -58,7 +58,7 @@ afterEvaluate {
                     licenses {
                         license {
                             name = 'Apache License'
-                            url = 'https://github.com/marcelpinto/permissions-ktx/blob/main/LICENSE'
+                            url = 'https://opensource.org/licenses/Apache-2.0'
                         }
                     }
                     developers {


### PR DESCRIPTION
Use a general public link to display license.
This makes it able to accept all license of a type that matches a SPDX identifier

Using https://github.com/cashapp/licensee you could accept using third party libraries with the some certain licenses instead of heaving a custom URL for each library

licensee {
    allow("Apache-2.0")
    allow("MIT")
}